### PR TITLE
refactor(s3): isolate s3 bucket calls

### DIFF
--- a/packages/providers/s3/src/provider.ts
+++ b/packages/providers/s3/src/provider.ts
@@ -1,12 +1,3 @@
-import {
-    DeleteObjectCommand,
-    DeleteObjectsCommand,
-    GetObjectCommand,
-    HeadObjectCommand,
-    PutObjectCommand,
-    S3ServiceException,
-} from '@aws-sdk/client-s3'
-import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { StorageServiceProvider } from '@providers/interface'
 import { FileStatus } from 'shared-types'
 
@@ -14,10 +5,6 @@ import { S3Clients } from './utils/s3-client'
 import { S3ProviderConfigurationParser } from './utils/s3-provider-configuration-parser'
 import { S3KeyResolvers } from './utils/s3-key-resolver'
 
-import type {
-    DeleteObjectCommandOutput,
-    DeleteObjectsCommandOutput,
-} from '@aws-sdk/client-s3'
 import type {
     DeleteRequest,
     GetDataRequest,

--- a/packages/providers/s3/src/types.ts
+++ b/packages/providers/s3/src/types.ts
@@ -1,5 +1,6 @@
 import { ObjectCannedACL } from '@aws-sdk/client-s3'
 import { z } from 'zod'
+import { S3ResourceBucket, S3UploadBucket } from './utils/s3-bucket'
 
 interface S3BucketConfiguration {
     bucketName?: string
@@ -118,3 +119,8 @@ export type S3ProviderConfigurationSchema = z.ZodSchema<
     z.ZodTypeDef,
     S3ProviderConfiguration
 >
+
+export interface Buckets<ID> {
+    upload: S3UploadBucket<ID>
+    resource: S3ResourceBucket<ID>
+}

--- a/packages/providers/s3/src/utils/s3-bucket.ts
+++ b/packages/providers/s3/src/utils/s3-bucket.ts
@@ -44,7 +44,7 @@ class S3Bucket<
 
     async keyExists(
         key: string,
-        commandInput: Omit<HeadObjectCommandInput, 'Bucket' | 'Key'>
+        commandInput?: Omit<HeadObjectCommandInput, 'Bucket' | 'Key'>
     ): Promise<boolean> {
         try {
             const command = new HeadObjectCommand({
@@ -75,7 +75,7 @@ export class S3UploadBucket<ID> extends S3Bucket<
     async getSignedUploadUrl(
         fileId: ID,
         expiresIn: ExpiresIn,
-        commandInput: Omit<PutObjectCommandInput, 'Bucket' | 'Key'>
+        commandInput?: Omit<PutObjectCommandInput, 'Bucket' | 'Key'>
     ) {
         const command = new PutObjectCommand({
             Bucket: this.name,
@@ -94,10 +94,12 @@ export class S3ResourceBucket<ID> extends S3Bucket<
     ID
 > {
     async getSignedDownloadUrl(
-        commandInput: Omit<GetObjectCommandInput, 'Bucket'>
+        key: string,
+        commandInput?: Omit<GetObjectCommandInput, 'Bucket' | 'Key'>
     ) {
         const command = new GetObjectCommand({
             Bucket: this.name,
+            Key: key,
             ...commandInput,
         })
 
@@ -111,7 +113,7 @@ export class S3ResourceBucket<ID> extends S3Bucket<
     ) {
         return Promise.all(
             keys.map((key) =>
-                this.getSignedDownloadUrl({ Key: key, ...commandInput })
+                this.getSignedDownloadUrl(key, { ...commandInput })
             )
         )
     }

--- a/packages/providers/s3/src/utils/s3-bucket.ts
+++ b/packages/providers/s3/src/utils/s3-bucket.ts
@@ -1,0 +1,160 @@
+import {
+    DeleteObjectsCommand,
+    DeleteObjectsCommandInput,
+    GetObjectCommand,
+    GetObjectCommandInput,
+    HeadObjectCommand,
+    HeadObjectCommandInput,
+    PutObjectCommand,
+    PutObjectCommandInput,
+    S3Client,
+    S3ServiceException,
+} from '@aws-sdk/client-s3'
+import { S3KeyResolver } from './s3-key-resolver'
+import {
+    S3DefaultBucketConfiguration,
+    S3ResourceBucketConfiguration,
+    S3ResourceBucketPath,
+} from '../types'
+import { ExpiresIn } from 'shared-types'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+
+class S3Bucket<
+    Config extends
+        | Required<S3DefaultBucketConfiguration>
+        | Required<S3ResourceBucketConfiguration>,
+    ID
+> {
+    readonly client: S3Client
+    readonly keyResolver: S3KeyResolver<Config['bucketPath'], ID>
+    readonly region: string
+    readonly name: string
+    readonly path: Config['bucketPath']
+
+    constructor(
+        client: S3Client,
+        keyResolver: S3KeyResolver<Config['bucketPath'], ID>,
+        s3Config: Config
+    ) {
+        this.client = client
+        this.keyResolver = keyResolver
+        this.region = s3Config.bucketRegion
+        this.name = s3Config.bucketName
+        this.path = s3Config.bucketPath
+    }
+
+    async keyExists(
+        key: string,
+        commandInput: Omit<HeadObjectCommandInput, 'Bucket' | 'Key'>
+    ): Promise<boolean> {
+        try {
+            const command = new HeadObjectCommand({
+                Bucket: this.name,
+                Key: key,
+                ...commandInput,
+            })
+
+            const { DeleteMarker } = await this.client.send(command)
+
+            return DeleteMarker !== true
+        } catch (error) {
+            if (error instanceof S3ServiceException) {
+                if (error.name === 'NotFound') {
+                    return false
+                }
+            }
+
+            throw error
+        }
+    }
+}
+
+export class S3UploadBucket<ID> extends S3Bucket<
+    Required<S3DefaultBucketConfiguration>,
+    ID
+> {
+    async getSignedUploadUrl(
+        fileId: ID,
+        expiresIn: ExpiresIn,
+        commandInput: Omit<PutObjectCommandInput, 'Bucket' | 'Key'>
+    ) {
+        const command = new PutObjectCommand({
+            Bucket: this.name,
+            Key: this.keyResolver.resolve(fileId),
+            ...commandInput,
+        })
+
+        return await getSignedUrl(this.client, command, {
+            expiresIn: expiresIn,
+        })
+    }
+}
+
+export class S3ResourceBucket<ID> extends S3Bucket<
+    Required<S3ResourceBucketConfiguration>,
+    ID
+> {
+    async getSignedDownloadUrl(
+        commandInput: Omit<GetObjectCommandInput, 'Bucket'>
+    ) {
+        const command = new GetObjectCommand({
+            Bucket: this.name,
+            ...commandInput,
+        })
+
+        return await getSignedUrl(this.client, command)
+    }
+
+    async getSignedDownloadUrls(
+        fileId: ID,
+        keys = this.keyResolver.resolve(fileId),
+        commandInput?: Omit<GetObjectCommandInput, 'Bucket' | 'Key'>
+    ) {
+        return Promise.all(
+            keys.map((key) =>
+                this.getSignedDownloadUrl({ Key: key, ...commandInput })
+            )
+        )
+    }
+
+    async deleteObjects(
+        fileId: ID,
+        commandInput?: Omit<DeleteObjectsCommandInput, 'Bucket' | 'Delete'> & {
+            Delete: Omit<DeleteObjectsCommandInput['Delete'], 'Objects'>
+        }
+    ) {
+        const keys = this.keyResolver.resolve(fileId)
+
+        const command = new DeleteObjectsCommand({
+            Bucket: this.name,
+            ...commandInput,
+            Delete: {
+                Objects: keys.map((key) => ({ Key: key })),
+                ...commandInput?.Delete,
+            },
+        })
+
+        return await this.client.send(command)
+    }
+
+    async existingKeys(
+        fileId: ID,
+        commandInput?: Omit<HeadObjectCommandInput, 'Bucket' | 'Key'>
+    ) {
+        const keys = this.keyResolver.resolve(fileId)
+
+        const responses = await Promise.all(
+            keys.map(async (key) => {
+                const exists = await this.keyExists(key, {
+                    ...commandInput,
+                })
+                return {
+                    key,
+                    exists,
+                }
+            })
+        )
+
+        return responses.filter((key) => key.exists).map((key) => key.key)
+    }
+}

--- a/packages/providers/s3/src/utils/s3-bucket.ts
+++ b/packages/providers/s3/src/utils/s3-bucket.ts
@@ -14,7 +14,6 @@ import { S3KeyResolver } from './s3-key-resolver'
 import {
     S3DefaultBucketConfiguration,
     S3ResourceBucketConfiguration,
-    S3ResourceBucketPath,
 } from '../types'
 import { ExpiresIn } from 'shared-types'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'

--- a/packages/providers/s3/src/utils/s3-client.ts
+++ b/packages/providers/s3/src/utils/s3-client.ts
@@ -38,11 +38,11 @@ export class S3Clients {
         }
     }
 
-    get uploadClient(): S3Client {
+    get upload(): S3Client {
         return this._uploadClient
     }
 
-    get resourceClient(): S3Client {
+    get resource(): S3Client {
         return this._resourceClient
     }
 }


### PR DESCRIPTION
The `S3Provider` didn't feel great to work with. It was easy to make mistakes writing incorrect s3 calls. Mainly because the command was created using the class configuration. This made it prone to errors, such as using the upload client with the resource bucket name. I addressed these issues in the following way:

1. Create dedicated classes for each bucket (`S3UploadBucket`, `S3ResourceBucket`).
   1.  Both are configured using the corresponding client, keyResolver, and bucket config.
   2. Each class implements dedicated functions for specific s3 interactions. This way, the correct s3 config is used.
   3. If needed, the developer can still pass additional s3 client command inputs.
2. Removed the resource URL creation that was done by hand. Originally this was created for public acls where signed URLs are not needed. However, this resulted in some issues that have been annoying to resolve. Thus, I removed it completely, in favour of the AWS URL signing function.